### PR TITLE
Reward Screen Update

### DIFF
--- a/Vivarium/Assets/Scenes/InGameUI.unity
+++ b/Vivarium/Assets/Scenes/InGameUI.unity
@@ -260,6 +260,7 @@ MonoBehaviour:
   Option1Icon: {fileID: 889610989}
   Option2Icon: {fileID: 1782914637}
   Option3Icon: {fileID: 159062428}
+  PlayerButtons: {fileID: 567326683}
 --- !u!114 &2853934
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -281,6 +282,7 @@ MonoBehaviour:
   PreviewBackButton: {fileID: 1773805342}
   UndoMoveButton: {fileID: 0}
   EndTurnButton: {fileID: 748127745}
+  PlayerButtons: {fileID: 567326683}
 --- !u!114 &2853935
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -830,6 +832,81 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 56939890}
+  m_CullTransparentMesh: 0
+--- !u!1 &58357150
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 58357151}
+  - component: {fileID: 58357153}
+  - component: {fileID: 58357152}
+  m_Layer: 5
+  m_Name: BGScreen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &58357151
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 58357150}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1394285596}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &58357152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 58357150}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.9137255}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &58357153
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 58357150}
   m_CullTransparentMesh: 0
 --- !u!1 &58843032 stripped
 GameObject:
@@ -2532,81 +2609,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 47f9a9ac0340aa045a42fe6591736bc5, type: 3}
---- !u!1 &272656447
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 272656448}
-  - component: {fileID: 272656450}
-  - component: {fileID: 272656449}
-  m_Layer: 5
-  m_Name: Background
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &272656448
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 272656447}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1394285596}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &272656449
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 272656447}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: c66a30ef1b82be64f8087a01bbadf3c6, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &272656450
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 272656447}
-  m_CullTransparentMesh: 0
 --- !u!1001 &272724742
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9630,7 +9632,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 272656448}
+  - {fileID: 58357151}
   - {fileID: 181659823}
   - {fileID: 106266674}
   - {fileID: 1870240770}

--- a/Vivarium/Assets/Scripts/Characters/CharacterController.cs
+++ b/Vivarium/Assets/Scripts/Characters/CharacterController.cs
@@ -78,17 +78,20 @@ public class CharacterController : MonoBehaviour
     /// </summary>
     public void Select()
     {
-        _isSelected = true;
-        if (!_hasMoved)
+        if(!GetGridPosition().IsObjective || IsEnemy)
         {
-            ShowMoveRadius();
-        }
-        UIController.Instance.ShowCharacterInfo(this);
-        OnSelect?.Invoke(this);
+            _isSelected = true;
+            if (!_hasMoved)
+            {
+                ShowMoveRadius();
+            }
+            UIController.Instance.ShowCharacterInfo(this);
+            OnSelect?.Invoke(this);
 
-        Dictionary<(int, int), Tile> tempDict = new Dictionary<(int, int), Tile>();
-        tempDict.Add((0, 0), GetGridPosition());
-        TileGridController.Instance.HighlightTiles(tempDict, GridHighlightRank.Secondary);
+            Dictionary<(int, int), Tile> tempDict = new Dictionary<(int, int), Tile>();
+            tempDict.Add((0, 0), GetGridPosition());
+            TileGridController.Instance.HighlightTiles(tempDict, GridHighlightRank.Secondary);
+        }
     }
 
     /// <summary>

--- a/Vivarium/Assets/Scripts/UI/PrepMenuUIController.cs
+++ b/Vivarium/Assets/Scripts/UI/PrepMenuUIController.cs
@@ -18,6 +18,7 @@ public class PrepMenuUIController : MonoBehaviour
     public Button PreviewBackButton;
     public Button UndoMoveButton;
     public Button EndTurnButton;
+    public GameObject PlayerButtons;
 
     private List<CharacterDetailsProfile> _existingProfiles = new List<CharacterDetailsProfile>();
     private MasterCameraScript _masterCamera;
@@ -67,6 +68,7 @@ public class PrepMenuUIController : MonoBehaviour
             UndoMoveButton?.gameObject.SetActive(true);
             EndTurnButton?.gameObject.SetActive(true);
             _masterCamera?.unlockCamera();
+            PlayerButtons.SetActive(true);
         });
 
 

--- a/Vivarium/Assets/Scripts/UI/RewardsUIController.cs
+++ b/Vivarium/Assets/Scripts/UI/RewardsUIController.cs
@@ -19,6 +19,8 @@ public class RewardsUIController : MonoBehaviour
     public Image Option2Icon;
     public Image Option3Icon;
 
+    public GameObject PlayerButtons;
+
     private List<int> _selectedRewards = new List<int>();
     private System.Action _nextLevelCallback;
     private List<Item> _rewards = new List<Item>();
@@ -111,6 +113,7 @@ public class RewardsUIController : MonoBehaviour
             RewardsText.text = "Choose two rewards!";
             ItemRewardsScreen(callback, possibleRewards);
         }
+        PlayerButtons.SetActive(false);
     }
     private void CharacterRewardsScreen(System.Action callback)
     {


### PR DESCRIPTION
- Updates reward screen UI to appear over the previous level, removing the old background.
- Within CharacterController, Select() was updated to not select a character at the end of the level, which made the character inventory UI active during reward selection.
- Player buttons (besides the pause button) were also made inactive while the rewards screen is visible.
https://trello.com/c/V2D3Qx75